### PR TITLE
🔨 New tests and refactoring

### DIFF
--- a/dht/mainline/indexingService_test.go
+++ b/dht/mainline/indexingService_test.go
@@ -1,0 +1,30 @@
+package mainline
+
+import (
+	"testing"
+)
+
+func TestUint16BE(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		v    uint16
+		want [2]byte
+	}{
+		{"zero", 0, [2]byte{0, 0}},
+		{"one", 1, [2]byte{0, 1}},
+		{"two", 2, [2]byte{0, 2}},
+		{"max", 0xFFFF, [2]byte{0xFF, 0xFF}},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := toBigEndianBytes(test.v)
+			if got != test.want {
+				t.Errorf("toBigEndianBytes(%v) = %v, want %v", test.v, got, test.want)
+			}
+		})
+	}
+}

--- a/dht/managers_test.go
+++ b/dht/managers_test.go
@@ -1,0 +1,48 @@
+package dht
+
+import (
+	"net"
+	"reflect"
+	"testing"
+	"time"
+)
+
+const (
+	ChanSize       = 20
+	MaxNeighbours  = 10
+	ManagerAddress = "0.0.0.0:2024"
+	PeerIP         = "192.168.1.1"
+	PeerPort       = 6931
+	DefaultTimeOut = 1 * time.Second
+)
+
+type TestResult struct {
+	infoHash  [20]byte
+	peerAddrs []net.TCPAddr
+}
+
+func (tr *TestResult) InfoHash() [20]byte {
+	return tr.infoHash
+}
+
+func (tr *TestResult) PeerAddrs() []net.TCPAddr {
+	return tr.peerAddrs
+}
+
+func TestChannelOutput(t *testing.T) {
+	t.Parallel()
+	manager := NewManager([]string{ManagerAddress}, DefaultTimeOut, MaxNeighbours)
+
+	result := &TestResult{
+		infoHash:  [20]byte{255},
+		peerAddrs: []net.TCPAddr{{IP: net.ParseIP(PeerIP), Port: PeerPort, Zone: ""}},
+	}
+	outputChan := make(chan Result, ChanSize)
+	manager.output = outputChan
+	manager.output <- result
+
+	receivedResult := <-outputChan
+	if !reflect.DeepEqual(receivedResult, result) {
+		t.Errorf("\nReceived result %v, \nExpected result %v", receivedResult, result)
+	}
+}

--- a/metadata/leech_test.go
+++ b/metadata/leech_test.go
@@ -2,10 +2,11 @@ package metadata
 
 import (
 	"bytes"
-	"github.com/anacrolix/torrent/bencode"
-	"github.com/anacrolix/torrent/metainfo"
 	"math"
 	"testing"
+
+	"github.com/anacrolix/torrent/bencode"
+	"github.com/anacrolix/torrent/metainfo"
 )
 
 func TestDecoder(t *testing.T) {

--- a/metadata/sink_test.go
+++ b/metadata/sink_test.go
@@ -17,10 +17,10 @@ func TestRandomDigit(t *testing.T) {
 func TestPeerId(t *testing.T) {
 	t.Parallel()
 	for i := 0; i < 100; i++ {
-		peerId := randomID()
-		lenPeerId := len(peerId)
-		if lenPeerId > 20 {
-			t.Errorf("peerId longer than 20 bytes: %s (%d)", peerId, lenPeerId)
+		peerID := randomID()
+		lenPeerID := len(peerID)
+		if lenPeerID > PeerIDLength {
+			t.Errorf("peerId longer than 20 bytes: %s (%d)", peerID, lenPeerID)
 		}
 	}
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,10 +1,11 @@
 package util
 
 import (
-	"golang.org/x/sys/unix"
 	"net"
 	"reflect"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestRoundToDecimal(t *testing.T) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,196 @@
+package util
+
+import (
+	"golang.org/x/sys/unix"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestRoundToDecimal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		input         float64
+		decimalPlaces int
+		want          float64
+	}{
+		{"round to 1 decimal places", 1.2345, 1, 1.2},
+		{"round to 2 decimal places", 1.2345, 2, 1.23},
+		{"round to 4 decimal places", 1.2345, 4, 1.2345},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := RoundToDecimal(test.input, test.decimalPlaces); got != test.want {
+				t.Errorf("RoundToDecimal() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestNetAddrToSockaddr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		addr *net.UDPAddr
+		want unix.Sockaddr
+	}{
+		{
+			name: "IPv4",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("192.0.2.1"),
+				Port: 8080,
+			},
+			want: &unix.SockaddrInet4{
+				Port: 8080,
+				Addr: [4]byte{192, 0, 2, 1},
+			},
+		},
+		{
+			name: "IPv6",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("2001:4860:4860::8888"),
+				Port: 8080,
+			},
+			want: &unix.SockaddrInet6{
+				Port: 8080,
+				Addr: [16]byte{32, 1, 72, 96, 72, 96, 0, 0, 0, 0, 0, 0, 0, 0, 136, 136},
+			},
+		},
+		{
+			name: "Invalid IP",
+			addr: &net.UDPAddr{
+				IP:   net.ParseIP("invalid"),
+				Port: 8080,
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := NetAddrToSockaddr(test.addr)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("NetAddrToSockaddr() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestSockaddrToUDPAddr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		sockAddr unix.Sockaddr
+		want     *net.UDPAddr
+	}{
+		{
+			name: "IPv4 with valid IP:Port",
+			sockAddr: &unix.SockaddrInet4{
+				Addr: [4]byte{192, 0, 2, 1},
+				Port: 8080,
+			},
+			want: &net.UDPAddr{
+				IP:   []byte{192, 0, 2, 1},
+				Port: 8080,
+			},
+		},
+		{
+			name: "IPv6 with invalid IP",
+			sockAddr: &unix.SockaddrInet6{
+				Addr: [16]byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+				Port: 9090,
+			},
+			want: nil,
+		},
+		{
+			name: "IPv6 with invalid ZoneId",
+			sockAddr: &unix.SockaddrInet6{
+				Addr:   [16]byte{32, 1, 72, 96, 72, 96, 0, 0, 0, 0, 0, 0, 0, 0, 136, 136},
+				Port:   8080,
+				ZoneId: 12345,
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := SockaddrToUDPAddr(test.sockAddr)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("SockaddrToUDPAddr() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsValidIPv6(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		ip   string
+		want bool
+	}{
+		{
+			ip:   "2001:4860:4860::8888",
+			want: true,
+		},
+		{
+			ip:   "192.0.2.1",
+			want: false,
+		},
+		{
+			ip:   "299.0.2.1",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.ip, func(t *testing.T) {
+			t.Parallel()
+			if got := IsValidIPv6(test.ip); got != test.want {
+				t.Errorf("IsValidIPv6() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func Test_getZone(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		name   string
+		zoneID uint32
+		want   string
+	}{
+		{
+			name:   "Zone1",
+			zoneID: 0,
+			want:   "",
+		},
+		{
+			name:   "Zone2",
+			zoneID: 1,
+			want:   "lo",
+		},
+		{
+			name:   "Zone3",
+			zoneID: 123456,
+			want:   "",
+		},
+	}
+	for _, tt := range tests {
+		test := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := getZone(test.zoneID); got != test.want {
+				t.Errorf("getZone() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"net"
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -165,32 +166,37 @@ func TestIsValidIPv6(t *testing.T) {
 func Test_getZone(t *testing.T) {
 	t.Parallel()
 	var tests = []struct {
-		name   string
-		zoneID uint32
-		want   string
+		name       string
+		zoneID     uint32
+		wantEmpty  bool
+		wantPrefix string
 	}{
 		{
-			name:   "Zone1",
-			zoneID: 0,
-			want:   "",
+			name:      "Zone1",
+			zoneID:    0,
+			wantEmpty: true,
 		},
 		{
-			name:   "Zone2",
-			zoneID: 1,
-			want:   "lo",
+			name:       "Zone2",
+			zoneID:     1,
+			wantEmpty:  false,
+			wantPrefix: "lo",
 		},
 		{
-			name:   "Zone3",
-			zoneID: 123456,
-			want:   "",
+			name:      "Zone3",
+			zoneID:    123456,
+			wantEmpty: true,
 		},
 	}
 	for _, tt := range tests {
 		test := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := getZone(test.zoneID); got != test.want {
-				t.Errorf("getZone() = %v, want %v", got, test.want)
+			got := getZone(test.zoneID)
+			if test.wantEmpty && got != "" {
+				t.Errorf("getZone() = %v, want empty", got)
+			} else if !strings.HasPrefix(got, test.wantPrefix) {
+				t.Errorf("getZone() = %v, want prefix %v", got, test.wantPrefix)
 			}
 		})
 	}


### PR DESCRIPTION
- 🎯 Increased tests coverage 33,3% (9,5%) ➡️ 47% (12%) (files)
- 🎲 Replaced `math/rand` to `crypto/rand` 
- 🧠 Simplified code complexity

I think we can add test [coverage](https://github.com/marketplace/actions/go-test-coverage) information in Github Actions

Including badge: 
![coverage](https://raw.githubusercontent.com/vladopajic/go-test-coverage/badges/.badges/main/coverage.svg)