### PR TITLE
feat(mainline): allow user-supplied bootstrap nodes

### DIFF
--- a/cmd/magneticod/main.go
+++ b/cmd/magneticod/main.go
@@ -21,7 +21,8 @@ type opFlags struct {
 	IndexerInterval     time.Duration
 	IndexerMaxNeighbors uint
 
-	LeechMaxN int
+	LeechMaxN          int
+	BootstrappingNodes []string
 }
 
 func main() {
@@ -41,7 +42,7 @@ func main() {
 		log.Fatalf("Could not open the database %s. %v", opFlags.DatabaseURL, err)
 	}
 
-	trawlingManager := dht.NewManager(opFlags.IndexerAddrs, opFlags.IndexerInterval, opFlags.IndexerMaxNeighbors)
+	trawlingManager := dht.NewManager(opFlags.IndexerAddrs, opFlags.IndexerInterval, opFlags.IndexerMaxNeighbors, opFlags.BootstrappingNodes)
 	metadataSink := metadata.NewSink(5*time.Second, opFlags.LeechMaxN)
 
 	// The Event Loop
@@ -83,6 +84,8 @@ func parseFlags() (*opFlags, error) {
 
 		LeechMaxN uint `long:"leech-max-n" description:"Maximum number of leeches." default:"1000"`
 		MaxRPS    uint `long:"max-rps" description:"Maximum requests per second." default:"0"`
+
+		BootstrappingNodes []string `long:"bootstrap-node" description:"Host(s) to be used for bootstrapping." default:"dht.tgragnato.it"`
 	}
 
 	opF := new(opFlags)
@@ -117,6 +120,7 @@ func parseFlags() (*opFlags, error) {
 	}
 
 	mainline.DefaultThrottleRate = int(cmdF.MaxRPS)
+	opF.BootstrappingNodes = cmdF.BootstrappingNodes
 
 	return opF, nil
 }

--- a/dht/mainline/indexingService_test.go
+++ b/dht/mainline/indexingService_test.go
@@ -62,7 +62,7 @@ func TestBasicIndexingService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers)
+			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers, []string{"dht.tgragnato.it"})
 			if is == nil {
 				t.Error("NewIndexingService() = nil, wanted != nil")
 			}

--- a/dht/managers.go
+++ b/dht/managers.go
@@ -23,14 +23,14 @@ type Manager struct {
 	indexingServices []Service
 }
 
-func NewManager(addrs []string, interval time.Duration, maxNeighbors uint) *Manager {
+func NewManager(addrs []string, interval time.Duration, maxNeighbors uint, bootstrappingNodes []string) *Manager {
 	manager := new(Manager)
 	manager.output = make(chan Result, 20)
 
 	for _, addr := range addrs {
 		service := mainline.NewIndexingService(addr, interval, maxNeighbors, mainline.IndexingServiceEventHandlers{
 			OnResult: manager.onIndexingResult,
-		})
+		}, bootstrappingNodes)
 		manager.indexingServices = append(manager.indexingServices, service)
 		service.Start()
 	}

--- a/dht/managers_test.go
+++ b/dht/managers_test.go
@@ -36,7 +36,7 @@ func TestChannelOutput(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, time.Second, MaxNeighbours)
+	manager := NewManager([]string{address}, time.Second, MaxNeighbours, []string{"dht.tgragnato.it"})
 	peerPort := rand.Intn(64511) + 1024
 
 	result := &TestResult{
@@ -62,7 +62,7 @@ func TestOnIndexingResult(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours)
+	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours, []string{"dht.tgragnato.it"})
 
 	result := mainline.IndexingResult{}
 	outputChan := make(chan Result, ChanSize)


### PR DESCRIPTION
Adds command line option --bootstrap-node to allow users to select which boostrap node to use.
Can be supplied multiple times for multiple nodes.
Currently uses the same "try-common-ports" principle as previously, so users cannot decide which port to use on the node (yet)