### PR TITLE
fix(mainline): Run initial index instantly

### DIFF
--- a/dht/mainline/indexingService.go
+++ b/dht/mainline/indexingService.go
@@ -79,7 +79,8 @@ func (is *IndexingService) Terminate() {
 }
 
 func (is *IndexingService) index() {
-	for range time.Tick(is.interval) {
+	ticker := time.NewTicker(is.interval)
+	for ; true; <-ticker.C {
 		if is.nodes.isEmpty() {
 			is.bootstrap()
 		} else {


### PR DESCRIPTION
The index() function always waits for the delay specified with --indexer-interval, this wait should not happen on the first loop iteration.