### PR TITLE
feat(dht): crawl only specified ip ranges

### DIFF
--- a/dht/mainline/indexingService.go
+++ b/dht/mainline/indexingService.go
@@ -42,7 +42,7 @@ func (ir IndexingResult) PeerAddrs() []net.TCPAddr {
 	return ir.peerAddrs
 }
 
-func NewIndexingService(laddr string, interval time.Duration, maxNeighbors uint, eventHandlers IndexingServiceEventHandlers, bootstrapNodes []string) *IndexingService {
+func NewIndexingService(laddr string, interval time.Duration, maxNeighbors uint, eventHandlers IndexingServiceEventHandlers, bootstrapNodes []string, filterNodes []string) *IndexingService {
 	service := new(IndexingService)
 	service.interval = interval
 	service.protocol = NewProtocol(
@@ -55,7 +55,7 @@ func NewIndexingService(laddr string, interval time.Duration, maxNeighbors uint,
 		},
 	)
 	service.nodeID = randomNodeID()
-	service.nodes = newRoutingTable(maxNeighbors)
+	service.nodes = newRoutingTable(maxNeighbors, filterNodes)
 	service.eventHandlers = eventHandlers
 
 	service.getPeersRequests = make(map[[2]byte][20]byte)

--- a/dht/mainline/indexingService.go
+++ b/dht/mainline/indexingService.go
@@ -42,7 +42,7 @@ func (ir IndexingResult) PeerAddrs() []net.TCPAddr {
 	return ir.peerAddrs
 }
 
-func NewIndexingService(laddr string, interval time.Duration, maxNeighbors uint, eventHandlers IndexingServiceEventHandlers, bootstrapNodes []string, filterNodes []string) *IndexingService {
+func NewIndexingService(laddr string, interval time.Duration, maxNeighbors uint, eventHandlers IndexingServiceEventHandlers, bootstrapNodes []string, filterNodes []net.IPNet) *IndexingService {
 	service := new(IndexingService)
 	service.interval = interval
 	service.protocol = NewProtocol(

--- a/dht/mainline/indexingService_test.go
+++ b/dht/mainline/indexingService_test.go
@@ -62,7 +62,7 @@ func TestBasicIndexingService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers, []string{"dht.tgragnato.it"}, []string{})
+			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers, []string{"dht.tgragnato.it"}, []net.IPNet{})
 			if is == nil {
 				t.Error("NewIndexingService() = nil, wanted != nil")
 			}

--- a/dht/mainline/indexingService_test.go
+++ b/dht/mainline/indexingService_test.go
@@ -62,7 +62,7 @@ func TestBasicIndexingService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers, []string{"dht.tgragnato.it"})
+			is := NewIndexingService(tt.laddr, tt.interval, tt.maxNeighbors, tt.eventHandlers, []string{"dht.tgragnato.it"}, []string{})
 			if is == nil {
 				t.Error("NewIndexingService() = nil, wanted != nil")
 			}

--- a/dht/mainline/routingTable.go
+++ b/dht/mainline/routingTable.go
@@ -12,20 +12,11 @@ type routingTable struct {
 	filterNodes  []net.IPNet
 }
 
-func newRoutingTable(maxNeighbors uint, filterNodes []string) *routingTable {
-	filter := []net.IPNet{}
-	for _, filterNode := range filterNodes {
-		_, ipNet, err := net.ParseCIDR(filterNode)
-		if err != nil {
-			continue
-		}
-		filter = append(filter, *ipNet)
-	}
-
+func newRoutingTable(maxNeighbors uint, filterNodes []net.IPNet) *routingTable {
 	return &routingTable{
 		nodes:        make([]net.UDPAddr, 0, maxNeighbors),
 		maxNeighbors: maxNeighbors,
-		filterNodes:  filter,
+		filterNodes:  filterNodes,
 	}
 }
 

--- a/dht/mainline/routingTable_test.go
+++ b/dht/mainline/routingTable_test.go
@@ -9,14 +9,14 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	t.Parallel()
 
 	t.Run("empty", func(t *testing.T) {
-		rt := newRoutingTable(0)
+		rt := newRoutingTable(0, nil)
 		if !rt.isEmpty() {
 			t.Error("expected empty routing table")
 		}
 	})
 
 	t.Run("empty adding port 0", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 0})
 		if !rt.isEmpty() {
 			t.Error("expected empty routing table")
@@ -24,7 +24,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("empty with loopback", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1234})
 		if !rt.isEmpty() {
 			t.Error("expected empty routing table")
@@ -32,7 +32,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("empty with private address", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(192, 168, 0, 1), Port: 1234})
 		if !rt.isEmpty() {
 			t.Error("expected empty routing table")
@@ -40,7 +40,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("not empty 80", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 80})
 		if rt.isEmpty() {
 			t.Error("expected non-empty routing table")
@@ -48,7 +48,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("empty 123", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 123})
 		if !rt.isEmpty() {
 			t.Error("expected empty routing table")
@@ -56,7 +56,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("not empty 443", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 443})
 		if rt.isEmpty() {
 			t.Error("expected non-empty routing table")
@@ -64,7 +64,7 @@ func Test_routingTable_isEmpty(t *testing.T) {
 	})
 
 	t.Run("not empty 1234", func(t *testing.T) {
-		rt := newRoutingTable(1)
+		rt := newRoutingTable(1, nil)
 		rt.addNode(net.UDPAddr{IP: net.IPv4(1, 1, 1, 1), Port: 1234})
 		if rt.isEmpty() {
 			t.Error("expected non-empty routing table")

--- a/dht/managers.go
+++ b/dht/managers.go
@@ -23,7 +23,7 @@ type Manager struct {
 	indexingServices []Service
 }
 
-func NewManager(addrs []string, interval time.Duration, maxNeighbors uint, bootstrappingNodes []string, filterNodes []string) *Manager {
+func NewManager(addrs []string, interval time.Duration, maxNeighbors uint, bootstrappingNodes []string, filterNodes []net.IPNet) *Manager {
 	manager := new(Manager)
 	manager.output = make(chan Result, 20)
 

--- a/dht/managers.go
+++ b/dht/managers.go
@@ -23,14 +23,14 @@ type Manager struct {
 	indexingServices []Service
 }
 
-func NewManager(addrs []string, interval time.Duration, maxNeighbors uint, bootstrappingNodes []string) *Manager {
+func NewManager(addrs []string, interval time.Duration, maxNeighbors uint, bootstrappingNodes []string, filterNodes []string) *Manager {
 	manager := new(Manager)
 	manager.output = make(chan Result, 20)
 
 	for _, addr := range addrs {
 		service := mainline.NewIndexingService(addr, interval, maxNeighbors, mainline.IndexingServiceEventHandlers{
 			OnResult: manager.onIndexingResult,
-		}, bootstrappingNodes)
+		}, bootstrappingNodes, filterNodes)
 		manager.indexingServices = append(manager.indexingServices, service)
 		service.Start()
 	}

--- a/dht/managers_test.go
+++ b/dht/managers_test.go
@@ -36,7 +36,7 @@ func TestChannelOutput(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, time.Second, MaxNeighbours, []string{"dht.tgragnato.it"}, []string{})
+	manager := NewManager([]string{address}, time.Second, MaxNeighbours, []string{"dht.tgragnato.it"}, []net.IPNet{})
 	peerPort := rand.Intn(64511) + 1024
 
 	result := &TestResult{
@@ -62,7 +62,7 @@ func TestOnIndexingResult(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours, []string{"dht.tgragnato.it"}, []string{})
+	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours, []string{"dht.tgragnato.it"}, []net.IPNet{})
 
 	result := mainline.IndexingResult{}
 	outputChan := make(chan Result, ChanSize)

--- a/dht/managers_test.go
+++ b/dht/managers_test.go
@@ -36,7 +36,7 @@ func TestChannelOutput(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, time.Second, MaxNeighbours, []string{"dht.tgragnato.it"})
+	manager := NewManager([]string{address}, time.Second, MaxNeighbours, []string{"dht.tgragnato.it"}, []string{})
 	peerPort := rand.Intn(64511) + 1024
 
 	result := &TestResult{
@@ -62,7 +62,7 @@ func TestOnIndexingResult(t *testing.T) {
 	t.Parallel()
 
 	address := ManagerAddress + ":" + strconv.Itoa(rand.Intn(64511)+1024)
-	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours, []string{"dht.tgragnato.it"})
+	manager := NewManager([]string{address}, DefaultTimeOut, MaxNeighbours, []string{"dht.tgragnato.it"}, []string{})
 
 	result := mainline.IndexingResult{}
 	outputChan := make(chan Result, ChanSize)

--- a/main.go
+++ b/main.go
@@ -35,6 +35,7 @@ var opFlags struct {
 
 	LeechMaxN          int
 	BootstrappingNodes []string
+	FilterNodesCIDRs   []string
 
 	Addr string
 
@@ -89,8 +90,8 @@ func main() {
 		return
 	}
 
-	trawlingManager := dht.NewManager(opFlags.IndexerAddrs, opFlags.IndexerInterval, opFlags.IndexerMaxNeighbors, opFlags.BootstrappingNodes)
-	metadataSink := metadata.NewSink(5*time.Second, opFlags.LeechMaxN)
+	trawlingManager := dht.NewManager(opFlags.IndexerAddrs, opFlags.IndexerInterval, opFlags.IndexerMaxNeighbors, opFlags.BootstrappingNodes, opFlags.FilterNodesCIDRs)
+	metadataSink := metadata.NewSink(5*time.Second, opFlags.LeechMaxN, opFlags.FilterNodesCIDRs)
 
 	// The Event Loop
 	for stopped := false; !stopped; {
@@ -129,6 +130,7 @@ func parseFlags() error {
 		MaxRPS    uint `long:"max-rps" description:"Maximum requests per second." default:"0"`
 
 		BootstrappingNodes []string `long:"bootstrap-node" description:"Host(s) to be used for bootstrapping." default:"dht.tgragnato.it"`
+		FilterNodesCIDRs   []string `long:"filter-nodes-cidrs" description:"List of CIDRs on which Magnetico can operate. Empty is open mode." default:""`
 
 		Addr string `short:"a" long:"addr"        description:"Address (host:port) to serve on" default:"[::1]:8080"`
 		Cred string `short:"c" long:"credentials" description:"Path to the credentials file" default:""`
@@ -184,6 +186,7 @@ func parseFlags() error {
 
 		mainline.DefaultThrottleRate = int(cmdF.MaxRPS)
 		opFlags.BootstrappingNodes = cmdF.BootstrappingNodes
+		opFlags.FilterNodesCIDRs = cmdF.FilterNodesCIDRs
 	}
 
 	return nil

--- a/metadata/infoHashes.go
+++ b/metadata/infoHashes.go
@@ -12,22 +12,12 @@ type infoHashes struct {
 	filterPeers []net.IPNet
 }
 
-func newInfoHashes(maxNLeeches int, filterPeers []string) *infoHashes {
-	filter := []net.IPNet{}
-	for _, filterPeer := range filterPeers {
-		_, ipNet, err := net.ParseCIDR(filterPeer)
-		if err != nil {
-			continue
-		}
-		filter = append(filter, *ipNet)
-	}
-
-	ih := &infoHashes{
+func newInfoHashes(maxNLeeches int, filterPeers []net.IPNet) *infoHashes {
+	return &infoHashes{
 		infoHashes:  make(map[[20]byte][]net.TCPAddr),
 		maxNLeeches: maxNLeeches,
-		filterPeers: filter,
+		filterPeers: filterPeers,
 	}
-	return ih
 }
 
 func (ih *infoHashes) isAllowed(peer net.TCPAddr) bool {

--- a/metadata/sink.go
+++ b/metadata/sink.go
@@ -39,7 +39,7 @@ type Sink struct {
 	termination chan interface{}
 }
 
-func NewSink(deadline time.Duration, maxNLeeches int, filterNodes []string) *Sink {
+func NewSink(deadline time.Duration, maxNLeeches int, filterNodes []net.IPNet) *Sink {
 	ms := new(Sink)
 
 	ms.PeerID = randomID()

--- a/metadata/sink.go
+++ b/metadata/sink.go
@@ -39,13 +39,13 @@ type Sink struct {
 	termination chan interface{}
 }
 
-func NewSink(deadline time.Duration, maxNLeeches int) *Sink {
+func NewSink(deadline time.Duration, maxNLeeches int, filterNodes []string) *Sink {
 	ms := new(Sink)
 
 	ms.PeerID = randomID()
 	ms.deadline = deadline
 	ms.drain = make(chan Metadata, 10)
-	ms.incomingInfoHashes = newInfoHashes(maxNLeeches)
+	ms.incomingInfoHashes = newInfoHashes(maxNLeeches, filterNodes)
 	ms.termination = make(chan interface{})
 
 	return ms

--- a/metadata/sink_test.go
+++ b/metadata/sink_test.go
@@ -10,7 +10,7 @@ import (
 func TestSink_NewSink(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Second, 10)
+	sink := NewSink(time.Second, 10, []string{})
 	if sink == nil ||
 		len(sink.PeerID) != 20 ||
 		sink.deadline != time.Second ||
@@ -37,7 +37,7 @@ func (tr *TestResult) PeerAddrs() []net.TCPAddr {
 func TestSink_Sink(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 2)
+	sink := NewSink(time.Minute, 2, []string{})
 	testResult := &TestResult{
 		infoHash:  [20]byte{255},
 		peerAddrs: []net.TCPAddr{{IP: net.ParseIP("1.0.0.1"), Port: 443}},
@@ -51,7 +51,7 @@ func TestSink_Sink(t *testing.T) {
 func TestSink_Terminate(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 1)
+	sink := NewSink(time.Minute, 1, []string{})
 	sink.Terminate()
 
 	if !sink.terminated {
@@ -68,7 +68,7 @@ func TestSink_Drain(t *testing.T) {
 		}
 	}()
 
-	sink := NewSink(time.Minute, 1)
+	sink := NewSink(time.Minute, 1, []string{})
 	sink.Terminate()
 	sink.Drain()
 }
@@ -76,7 +76,7 @@ func TestSink_Drain(t *testing.T) {
 func TestFlush(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 1)
+	sink := NewSink(time.Minute, 1, []string{})
 	testMetadata := Metadata{
 		InfoHash: []byte{1, 2, 3, 4, 5, 6},
 	}

--- a/metadata/sink_test.go
+++ b/metadata/sink_test.go
@@ -10,7 +10,7 @@ import (
 func TestSink_NewSink(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Second, 10, []string{})
+	sink := NewSink(time.Second, 10, []net.IPNet{})
 	if sink == nil ||
 		len(sink.PeerID) != 20 ||
 		sink.deadline != time.Second ||
@@ -37,7 +37,7 @@ func (tr *TestResult) PeerAddrs() []net.TCPAddr {
 func TestSink_Sink(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 2, []string{})
+	sink := NewSink(time.Minute, 2, []net.IPNet{})
 	testResult := &TestResult{
 		infoHash:  [20]byte{255},
 		peerAddrs: []net.TCPAddr{{IP: net.ParseIP("1.0.0.1"), Port: 443}},
@@ -51,7 +51,7 @@ func TestSink_Sink(t *testing.T) {
 func TestSink_Terminate(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 1, []string{})
+	sink := NewSink(time.Minute, 1, []net.IPNet{})
 	sink.Terminate()
 
 	if !sink.terminated {
@@ -68,7 +68,7 @@ func TestSink_Drain(t *testing.T) {
 		}
 	}()
 
-	sink := NewSink(time.Minute, 1, []string{})
+	sink := NewSink(time.Minute, 1, []net.IPNet{})
 	sink.Terminate()
 	sink.Drain()
 }
@@ -76,7 +76,7 @@ func TestSink_Drain(t *testing.T) {
 func TestFlush(t *testing.T) {
 	t.Parallel()
 
-	sink := NewSink(time.Minute, 1, []string{})
+	sink := NewSink(time.Minute, 1, []net.IPNet{})
 	testMetadata := Metadata{
 		InfoHash: []byte{1, 2, 3, 4, 5, 6},
 	}


### PR DESCRIPTION
Ref: https://github.com/tgragnato/magnetico/issues/361

`Opentracker` itself does not implement a DHT node or direct support for **_bootstrapping a DHT network_**. Instead, Opentracker functions as a traditional tracker, using the HTTP/UDP protocols to manage peer lists and facilitate the sharing process.

To bootstrap the DHT for local torrent nodes, you would typically rely on the BitTorrent clients themselves to handle DHT operations. These clients maintain lists of known DHT nodes and can join the DHT network to find peers for torrents even without a central tracker.

If you want to create a custom DHT bootstrap node for a private network, **_you might need to run a BitTorrent client in DHT-only mode_** or modify an existing client to act as a persistent DHT node, but this falls outside the typical use of Opentracker. 