### PR TITLE
Implement ZeroMQ interface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /workspace
 COPY go.mod .
 COPY go.sum .
 COPY . .
-RUN apk add --no-cache alpine-sdk && go mod download && go build --tags fts5 . && go build --tags fts5 .
+RUN apk add --no-cache alpine-sdk libsodium-dev zeromq-dev czmq-dev && go mod download && go build --tags fts5 . && go build --tags fts5 .
 
 FROM alpine:3.20
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache alpine-sdk && go mod download && go build --tags fts5 . &
 FROM alpine:3.20
 WORKDIR /tmp
 COPY --from=builder /workspace/magnetico /usr/bin/
-RUN apk add --no-cache libstdc++ libgcc \
+RUN apk add --no-cache libstdc++ libgcc libsodium-dev libzmq czmq \
     && echo '#!/bin/sh' >> /usr/bin/magneticod \
     && echo '/usr/bin/magnetico "$@" --daemon' >> /usr/bin/magneticod \
     && chmod +x /usr/bin/magneticod \

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/multiformats/go-multihash v0.2.3
+	github.com/patrickmn/go-cache v2.1.0+incompatible
+	github.com/zeromq/goczmq v4.1.0+incompatible
 	golang.org/x/crypto v0.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7B
 github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -45,6 +47,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+github.com/zeromq/goczmq v4.1.0+incompatible h1:cGVQaU6kIwwrGso0Pgbl84tzAz/h7FJ3wYQjSonjFFc=
+github.com/zeromq/goczmq v4.1.0+incompatible/go.mod h1:1uZybAJoSRCvZMH2rZxEwWBSmC4T7CB/xQOfChwPEzg=
 golang.org/x/crypto v0.26.0 h1:RrRspgV4mU+YwB4FYnuBoKsUapNIL5cohGAmSH3azsw=
 golang.org/x/crypto v0.26.0/go.mod h1:GY7jblb9wI+FOo5y8/S2oY4zWP07AkOJ4+jxCqdqn54=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -60,6 +60,7 @@ const (
 	Sqlite3 databaseEngine = iota + 1
 	Postgres
 	Cockroach
+	ZeroMQ
 )
 
 type Statistics struct {
@@ -113,6 +114,9 @@ func MakeDatabase(rawURL string) (Database, error) {
 
 	case "postgres", "cockroach":
 		return makePostgresDatabase(url_)
+
+	case "zeromq", "zmq":
+		return makeZeroMQ(url_)
 
 	default:
 		return nil, fmt.Errorf("unknown URI scheme: `%s`", url_.Scheme)

--- a/persistence/zeromq.go
+++ b/persistence/zeromq.go
@@ -50,7 +50,6 @@ func (instance *zeromq) AddNewTorrent(infoHash []byte, name string, files []File
 		return errors.New("Failed to transmit " + err.Error())
 	}
 	instance.cache.Set(string(infoHash), data, cache.DefaultExpiration)
-	//zap.L().Debug(string(data))
 	return nil
 }
 

--- a/persistence/zeromq.go
+++ b/persistence/zeromq.go
@@ -1,0 +1,88 @@
+package persistence
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"github.com/patrickmn/go-cache"
+	zmq "github.com/zeromq/goczmq"
+	"net/url"
+	"time"
+)
+
+type zeromq struct {
+	context *zmq.Sock
+	cache   *cache.Cache
+}
+
+func makeZeroMQ(url_ *url.URL) (Database, error) {
+	url_.Scheme = "tcp"
+	instance := new(zeromq)
+	context, err := zmq.NewPub(url_.String())
+	if err != nil {
+		return nil, err
+	}
+	instance.context = context
+	instance.cache = cache.New(5*time.Minute, 10*time.Minute)
+	return instance, nil
+}
+
+func (instance *zeromq) Engine() databaseEngine {
+	return ZeroMQ
+}
+
+func (instance *zeromq) DoesTorrentExist(infoHash []byte) (bool, error) {
+	_, found := instance.cache.Get(string(infoHash))
+	return found, nil
+}
+
+func (instance *zeromq) AddNewTorrent(infoHash []byte, name string, files []File) error {
+	data, err := json.Marshal(SimpleTorrentSummary{
+		InfoHash: hex.EncodeToString(infoHash),
+		Name:     name,
+		Files:    files,
+	})
+	if err != nil {
+		return errors.New("Failed to encode metadata " + err.Error())
+	}
+	err = instance.context.SendMessage([][]byte{data})
+	if err != nil {
+		return errors.New("Failed to transmit " + err.Error())
+	}
+	instance.cache.Set(string(infoHash), data, cache.DefaultExpiration)
+	//zap.L().Debug(string(data))
+	return nil
+}
+
+func (instance *zeromq) Close() error {
+	instance.context.Destroy()
+	return nil
+}
+
+func (instance *zeromq) GetNumberOfTorrents() (uint, error) {
+	return 0, nil
+}
+
+func (instance *zeromq) QueryTorrents(
+	query string,
+	epoch int64,
+	orderBy OrderingCriteria,
+	ascending bool,
+	limit uint,
+	lastOrderedValue *float64,
+	lastID *uint64,
+) ([]TorrentMetadata, error) {
+	return nil, errors.New("query not supported")
+}
+
+func (instance *zeromq) GetTorrent(infoHash []byte) (*TorrentMetadata, error) {
+	return nil, errors.New("fetch not supported")
+}
+
+func (instance *zeromq) GetFiles(infoHash []byte) ([]File, error) {
+	return nil, errors.New("file fetch not supported")
+}
+
+func (instance *zeromq) GetStatistics(from string, n uint) (*Statistics, error) {
+	return nil, errors.New("statistics not supported")
+}


### PR DESCRIPTION
Hey tgragnato!

I "maintain" a [fork](https://github.com/Fabricio20/magnetico) of the original magneticod which focuses on just keeping the crawler alive as the bare minimum, however my golang experience is extremely limited (you can see that painful journey [here](https://github.com/boramalper/magnetico/compare/master...Fabricio20:magnetico:master)).

I have a personal use case that requires reading the raw data/results coming from the crawling process, I chose ZeroMQ for that and implemented it on my fork. This pull request brings that feature over to your fork.

It's implemented as an extra database type, works under the `zeromq` and `zmq` url schemas, and functionality wise it just's a [ZMQ PUB](https://rfc.zeromq.org/spec/29/#the-pub-socket-type) firehose. It also has a small in-memory cache, this is necessary because otherwise [the crawler keeps re-requesting the same torrent files in a loop](https://github.com/tgragnato/magnetico/blob/main/main.go#L106), this is of course not an issue when you have an actual underlying database.

I've tested the changes on this pull request under linux (more specifically, via building the docker image) and everything seems to be working as intended, I also noticed your fork has a lot more performance than the original! Do let me know if any of these changes break something for you, specially the whole libsodium, zeromq and czmq dependencies that are necessary in the build process.