### PR TITLE
Function enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ The integration is designed in the persistence layer as a ZMQ PUB firehose, and 
 - `docker run --rm -it ghcr.io/tgragnato/magnetico:latest --help`
 - `docker run --rm -it ghcr.io/tgragnato/magnetico:latest -d --database=zeromq://localhost:5555`
 
+### RabbitMQ
+
+RabbitMQ is an open-source message broker that facilitates communication between distributed systems by queuing and routing messages. It supports multiple messaging protocols and ensures reliable message delivery for scalable applications.
+The integration is designed in the persistence layer following the Publish/Subscribe model, and operates over a durable queue named `magnetico` routed through an exchange.
+
+- `docker run --rm -it ghcr.io/tgragnato/magnetico:latest --help`
+- `docker run --rm -it ghcr.io/tgragnato/magnetico:latest -d --database=amqp://localhost:5672`
+
 ## Features
 
 Easy installation & minimal requirements:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.20.5
+	github.com/rabbitmq/amqp091-go v1.10.0
 	golang.org/x/crypto v0.29.0
 	gopkg.in/zeromq/goczmq.v4 v4.1.0
 )
@@ -19,6 +20,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.15.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
@@ -28,6 +30,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.60.1 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/bits-and-blooms/bloom/v3 v3.7.0/go.mod h1:VKlUSvp0lFIYqxJjzdnSsZEw4iH
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
+github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
@@ -45,8 +45,9 @@ github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/n
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
 github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
@@ -55,6 +56,8 @@ github.com/prometheus/common v0.60.1 h1:FUas6GcOw66yB/73KC+BOZoFJmbo/1pojoILArPA
 github.com/prometheus/common v0.60.1/go.mod h1:h0LYf1R1deLSKtD4Vdg8gy4RuOvENW2J/h19V5NADQw=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
+github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -64,6 +67,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.29.0 h1:L5SG1JTTXupVV3n6sUqMTeWbjAyfPwoda2DLX8J8FrQ=
 golang.org/x/crypto v0.29.0/go.mod h1:+F4F4N5hv6v38hfeYwTdx20oUvLLc+QfrE9Ax9HtgRg=
 golang.org/x/sync v0.9.0 h1:fEo0HyrW1GIgZdpbhCRO0PkJajUS5H9IFUztCgEo2jQ=

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -118,7 +118,7 @@ func MakeDatabase(rawURL string) (Database, error) {
 	case "zeromq", "zmq":
 		return makeZeroMQ(url_)
 
-	case "amqp":
+	case "amqp", "amqps":
 		return makeRabbitMQ(url_)
 
 	default:

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -60,6 +60,7 @@ const (
 	Sqlite3 databaseEngine = iota + 1
 	Postgres
 	ZeroMQ
+	RabbitMQ
 )
 
 type Statistics struct {
@@ -116,6 +117,9 @@ func MakeDatabase(rawURL string) (Database, error) {
 
 	case "zeromq", "zmq":
 		return makeZeroMQ(url_)
+
+	case "amqp":
+		return makeRabbitMQ(url_)
 
 	default:
 		return nil, fmt.Errorf("unknown URI scheme: `%s`", url_.Scheme)

--- a/persistence/rabbitmq.go
+++ b/persistence/rabbitmq.go
@@ -1,0 +1,159 @@
+package persistence
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/url"
+	"time"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type rabbitMQ struct {
+	// todo: This is just a simple use now, you need to be able to customize it later.
+	conn     *amqp.Connection
+	ch       *amqp.Channel
+	exchange string
+	key      string
+
+	dataQueue amqp.Queue
+
+	ReconnectDelay time.Duration //todo: In the future, the reconnection interval of the rabbitmq queue will be controlled here.
+
+	globalCtx        context.Context
+	globalCtxCanFunc context.CancelFunc
+}
+
+func makeRabbitMQ(url_ *url.URL) (Database, error) {
+	var err error
+	// url_.Scheme = "amqp"
+	rmq := new(rabbitMQ)
+	rmq.globalCtx, rmq.globalCtxCanFunc = context.WithCancel(context.Background())
+	publishCtx, publishCtxCanFunc := context.WithTimeout(rmq.globalCtx, 5*time.Second)
+	defer publishCtxCanFunc()
+
+	rmq.conn, err = amqp.Dial(url_.String())
+	if err != nil {
+		return nil, err
+	}
+	rmq.ch, err = rmq.conn.Channel()
+	if err != nil {
+		return nil, err
+	}
+
+	statusNotifyQueue, err := rmq.ch.QueueDeclare(
+		"hello",
+		false,
+		false,
+		false,
+		false,
+		nil,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err = rmq.ch.PublishWithContext(publishCtx,
+		"",
+		statusNotifyQueue.Name,
+		false,
+		false,
+		amqp.Publishing(amqp.Publishing{
+			ContentType: "text/plain",
+			Body:        []byte("Hello"),
+		})); err != nil {
+		return nil, err
+	}
+
+	rmq.dataQueue, err = rmq.ch.QueueDeclare(
+		"magnet_data",
+		true,
+		false,
+		false,
+		false,
+		nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return rmq, nil
+}
+
+func (r *rabbitMQ) Engine() databaseEngine {
+	return RabbitMQ
+}
+
+func (r *rabbitMQ) DoesTorrentExist(infoHash []byte) (bool, error) {
+	return false, nil
+}
+
+func (r *rabbitMQ) AddNewTorrent(infoHash []byte, name string, files []File) error {
+
+	data, err := json.Marshal(SimpleTorrentSummary{
+		InfoHash: hex.EncodeToString(infoHash),
+		Name:     name,
+		Files:    files,
+	})
+	if err != nil {
+		return errors.New("failed to encode metadata " + err.Error())
+	}
+
+	dataSize := len(data)
+	if dataSize > 4708106 {
+		return errors.New("encode data exceeds maximum 4708106")
+	}
+
+	publishCtx, canCtx := context.WithTimeout(r.globalCtx, 5*time.Second)
+	defer canCtx()
+
+	if err = r.ch.PublishWithContext(publishCtx,
+		"",
+		r.dataQueue.Name,
+		false,
+		false,
+		amqp.Publishing(amqp.Publishing{
+			Body: data,
+		})); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *rabbitMQ) Close() error {
+	var err error
+	err = r.ch.Close()
+	if err != nil {
+		return err
+	}
+	err = r.conn.Close()
+	if err != nil {
+		return err
+	}
+	log.Println("successfully closed rabbitmq")
+	return nil
+}
+
+func (r *rabbitMQ) GetNumberOfTorrents() (uint, error) {
+	return 0, nil
+}
+
+func (r *rabbitMQ) QueryTorrents(query string, epoch int64, orderBy OrderingCriteria, ascending bool, limit uint64, lastOrderedValue *float64, lastID *uint64) ([]TorrentMetadata, error) {
+	return nil, errors.New("query not supported")
+}
+
+func (r *rabbitMQ) GetTorrent(infoHash []byte) (*TorrentMetadata, error) {
+	return nil, errors.New("fetch not supported")
+}
+
+func (r *rabbitMQ) GetFiles(infoHash []byte) ([]File, error) {
+	return nil, errors.New("file fetch not supported")
+}
+
+func (r *rabbitMQ) GetStatistics(from string, n uint) (*Statistics, error) {
+	return nil, errors.New("statistics not supported")
+}


### PR DESCRIPTION
# Functional enhancements

Introduction: I am just a programming amateur. These newly added functions may seem very confusing.

## Add support RabbitMQ
### introduce:<br />
Simple support for rabbitmq, currently only supports the Publish/Subscribe model of amqp, where the switch uses the default one of rabbitmq.

### **How to use:**<br />
Create a vhost, for example: `magnetico`.

Fill in the database address like this
`amqp://name:password@localhost:port/magnetico`
<br>After starting, you will see it in the rabbitmq gui interface:

![image](https://github.com/user-attachments/assets/d3024bd6-4a37-4c0d-8d4a-92ce38d7d73f)

`hello` is used to test the connectivity with rabbitmq,<br />
`magnet_data` contains byte type metadata.

## Add support for customizing individual ports for bootstrap nodes.
### introduce:<br />
This feature allows to specify the communication port for bootstrapNodes at program startup.
### **How to use:**<br />
When starting, pass in the `--is-bootstrap-node-self-port` parameter and the `--bootstrap-node=xxx:port` parameter to use the specified communication port.

For example: `magntico --is-bootstrap-node-self-port --bootstrap-node=router.bittorrent.com:6881`

If you do not want to use the specified port function, pass in the `--bootstrap-node=router.bittorrent.com` parameter like this.

## Add support for loading configuration from yaml files.
### introduce:<br />
Configuration files can be loaded from yaml files.

### **How to use:**<br />
**Required parameters:** Pass at least `--with-config-file` when starting.<br/>
**Optional parameter:** `--config-file-path` specifies the path to the yaml configuration file. If you do not fill in this parameter, it will default to the config.yml file under the program for loading.

For example: `magnetico --with-config-file or magnetico --with-config-file --config-file-path=/con/file/path/run.yml`

config.yml:
```
databaseURL: "amqp://rabbitmq:rabbitmq@localhost:5672/magnetico"
indexerAddrs: "0.0.0.0:0"
indexerMaxNeighbors: 600
leechMaxN: 700
maxRPS: 600
bootstrappingNodes: "dht.libtorrent.org:25401,dht.transmissionbt.com:6881,router.bittorrent.com:6881,router.utorrent.com:6881,dht.aelitis.com:6881"
bootstrapNodesSelfPort: true
filterNodesCIDRs: ""
addr: "0.0.0.0:8965"
cred: ""
runDaemon: true
runWeb: false
```