### PR TITLE
Add Pagination Functionality

### DIFF
--- a/persistence/bitmagnet.go
+++ b/persistence/bitmagnet.go
@@ -125,6 +125,10 @@ func (b *bitmagnet) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
+func (b *bitmagnet) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+	return 0, nil
+}
+
 func (b *bitmagnet) QueryTorrents(query string, epoch int64, orderBy OrderingCriteria, ascending bool, limit uint64, lastOrderedValue *float64, lastID *uint64) ([]TorrentMetadata, error) {
 	return nil, errors.New("query not supported")
 }

--- a/persistence/bitmagnet.go
+++ b/persistence/bitmagnet.go
@@ -125,7 +125,7 @@ func (b *bitmagnet) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
-func (b *bitmagnet) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (b *bitmagnet) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 	return 0, nil
 }
 

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -18,7 +18,7 @@ type Database interface {
 	// approximation.
 	GetNumberOfTorrents() (uint, error)
 	// GetNumberOfQueryTorrents returns the total number of data records in a fuzzy query.
-	GetNumberOfQueryTorrents(query string, epoch int64) (uint, error)
+	GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error)
 	// QueryTorrents returns @pageSize amount of torrents,
 	// * that are discovered before @discoveredOnBefore
 	// * that match the @query if it's not empty, else all torrents

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -17,6 +17,8 @@ type Database interface {
 	// GetNumberOfTorrents returns the number of torrents saved in the database. Might be an
 	// approximation.
 	GetNumberOfTorrents() (uint, error)
+	// GetNumberOfQueryTorrents returns the total number of data records in a fuzzy query.
+	GetNumberOfQueryTorrents(query string, epoch int64) (uint, error)
 	// QueryTorrents returns @pageSize amount of torrents,
 	// * that are discovered before @discoveredOnBefore
 	// * that match the @query if it's not empty, else all torrents

--- a/persistence/postgres.go
+++ b/persistence/postgres.go
@@ -167,7 +167,7 @@ func (db *postgresDatabase) GetNumberOfTorrents() (uint, error) {
 	}
 }
 
-func (db *postgresDatabase) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (db *postgresDatabase) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 
 	var querySkeleton = `SELECT COUNT(*)
 		FROM torrents
@@ -192,10 +192,10 @@ func (db *postgresDatabase) GetNumberOfQueryTorrents(query string, epoch int64) 
 	}
 
 	// If the database is empty (i.e. 0 entries in 'torrents') then the query will return nil.
-	if n == nil {
+	if n == nil || *n < 0 {
 		return 0, nil
 	} else {
-		return uint(*n), nil
+		return uint64(*n), nil
 	}
 }
 

--- a/persistence/postgres_test.go
+++ b/persistence/postgres_test.go
@@ -180,7 +180,7 @@ func TestPostgresDatabase_GetNumberOfQueryTorrents(t *testing.T) {
 		t.Errorf("Expected no error, but got %v", err)
 	}
 
-	if result != uint(10) {
+	if result != uint64(10) {
 		t.Errorf("Expected result to be 10, but got %d", result)
 	}
 
@@ -199,7 +199,7 @@ func TestPostgresDatabase_GetNumberOfQueryTorrents(t *testing.T) {
 		t.Error("Expected an error, but got none")
 	}
 
-	if result != uint(0) {
+	if result != uint64(0) {
 		t.Errorf("Expected result to be 0, but got %d", result)
 	}
 
@@ -218,7 +218,7 @@ func TestPostgresDatabase_GetNumberOfQueryTorrents(t *testing.T) {
 		t.Errorf("Expected no error, but got %v", err)
 	}
 
-	if result != uint(0) {
+	if result != uint64(0) {
 		t.Errorf("Expected result to be 0, but got %d", result)
 	}
 

--- a/persistence/rabbitmq.go
+++ b/persistence/rabbitmq.go
@@ -136,6 +136,10 @@ func (r *rabbitMQ) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
+func (r *rabbitMQ) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+	return 0, nil
+}
+
 func (r *rabbitMQ) QueryTorrents(query string, epoch int64, orderBy OrderingCriteria, ascending bool, limit uint64, lastOrderedValue *float64, lastID *uint64) ([]TorrentMetadata, error) {
 	return nil, errors.New("query not supported")
 }

--- a/persistence/rabbitmq.go
+++ b/persistence/rabbitmq.go
@@ -136,7 +136,7 @@ func (r *rabbitMQ) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
-func (r *rabbitMQ) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (r *rabbitMQ) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 	return 0, nil
 }
 

--- a/persistence/sqlite3.go
+++ b/persistence/sqlite3.go
@@ -228,6 +228,36 @@ func (db *sqlite3Database) GetNumberOfTorrents() (uint, error) {
 	}
 }
 
+func (db *sqlite3Database) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+	var querySkeleton = `SELECT COUNT(*)
+	FROM torrents
+	WHERE
+    	LOWER(name) LIKE '%' || LOWER($1) || '%' AND
+    	discovered_on <= $2;
+	`
+	rows, err := db.conn.Query(querySkeleton, query, epoch)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return 0, fmt.Errorf("no rows returned from `SELECT COUNT(*) FROM torrents WHERE LOWER(name) LIKE '%%' || LOWER($1) || '%%' AND discovered_on <= $2;`")
+	}
+
+	var n *uint
+	if err = rows.Scan(&n); err != nil {
+		return 0, err
+	}
+
+	// If the database is empty (i.e. 0 entries in 'torrents') then the query will return nil.
+	if n == nil {
+		return 0, nil
+	} else {
+		return *n, nil
+	}
+}
+
 func (db *sqlite3Database) QueryTorrents(
 	query string,
 	epoch int64,

--- a/persistence/sqlite3.go
+++ b/persistence/sqlite3.go
@@ -228,7 +228,7 @@ func (db *sqlite3Database) GetNumberOfTorrents() (uint, error) {
 	}
 }
 
-func (db *sqlite3Database) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (db *sqlite3Database) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 	var querySkeleton = `SELECT COUNT(*)
 	FROM torrents
 	WHERE
@@ -254,7 +254,7 @@ func (db *sqlite3Database) GetNumberOfQueryTorrents(query string, epoch int64) (
 	if n == nil {
 		return 0, nil
 	} else {
-		return *n, nil
+		return uint64(*n), nil
 	}
 }
 

--- a/persistence/sqlite3_test.go
+++ b/persistence/sqlite3_test.go
@@ -73,6 +73,12 @@ func Test_sqlite3Database_GetNumberOfTorrents(t *testing.T) {
 	}
 }
 
+func TestSqlite3Database_GetNumberOfQueryTorrents(t *testing.T) {
+	t.Parallel()
+	//todo implement me
+	t.Fatal("todo implement me!")
+}
+
 func Test_sqlite3Database_AddNewTorrent(t *testing.T) {
 	t.Parallel()
 	db := newDb(t)

--- a/persistence/sqlite3_test.go
+++ b/persistence/sqlite3_test.go
@@ -82,7 +82,7 @@ func TestSqlite3Database_GetNumberOfQueryTorrents(t *testing.T) {
 		name    string
 		query   string
 		epoch   int64
-		want    uint
+		want    uint64
 		wantErr bool
 	}{
 		{

--- a/persistence/sqlite3_test.go
+++ b/persistence/sqlite3_test.go
@@ -75,8 +75,65 @@ func Test_sqlite3Database_GetNumberOfTorrents(t *testing.T) {
 
 func TestSqlite3Database_GetNumberOfQueryTorrents(t *testing.T) {
 	t.Parallel()
-	//todo implement me
-	t.Fatal("todo implement me!")
+	db := newDb(t)
+
+	// The database is empty, so the number of torrents for any query should be 0.
+	tests := []struct {
+		name    string
+		query   string
+		epoch   int64
+		want    uint
+		wantErr bool
+	}{
+		{
+			name:    "Test Empty Query",
+			query:   "",
+			epoch:   0,
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "Test Simple Query",
+			query:   "test",
+			epoch:   0,
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "Test Query with Special Characters",
+			query:   "test!@#$%^&*()",
+			epoch:   0,
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "Test Query with Future Epoch",
+			query:   "test",
+			epoch:   32503680000, // January 1, 3000
+			want:    0,
+			wantErr: false,
+		},
+		{
+			name:    "Test Query with Past Epoch",
+			query:   "test",
+			epoch:   1000000000, // September 9, 2001
+			want:    0,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.GetNumberOfQueryTorrents(tt.query, tt.epoch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sqlite3Database.GetNumberOfQueryTorrents() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("sqlite3Database.GetNumberOfQueryTorrents() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func Test_sqlite3Database_AddNewTorrent(t *testing.T) {

--- a/persistence/zeromq.go
+++ b/persistence/zeromq.go
@@ -90,7 +90,7 @@ func (instance *zeromq) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
-func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 	return 0, nil
 }
 

--- a/persistence/zeromq.go
+++ b/persistence/zeromq.go
@@ -90,6 +90,10 @@ func (instance *zeromq) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
+func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+	return 0, nil
+}
+
 func (instance *zeromq) QueryTorrents(
 	query string,
 	epoch int64,

--- a/persistence/zeromq_mock.go
+++ b/persistence/zeromq_mock.go
@@ -34,6 +34,10 @@ func (instance *zeromq) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
+func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+	return 0, nil
+}
+
 func (instance *zeromq) QueryTorrents(
 	query string,
 	epoch int64,

--- a/persistence/zeromq_mock.go
+++ b/persistence/zeromq_mock.go
@@ -34,7 +34,7 @@ func (instance *zeromq) GetNumberOfTorrents() (uint, error) {
 	return 0, nil
 }
 
-func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint, error) {
+func (instance *zeromq) GetNumberOfQueryTorrents(query string, epoch int64) (uint64, error) {
 	return 0, nil
 }
 

--- a/web/router.go
+++ b/web/router.go
@@ -57,6 +57,7 @@ func makeRouter() *http.ServeMux {
 
 	router.HandleFunc("/api/v0.1/statistics", BasicAuth(apiStatistics))
 	router.HandleFunc("/api/v0.1/torrents", BasicAuth(apiTorrents))
+	router.HandleFunc("/api/v0.1/torrentstotal", BasicAuth(apiTorrentsTotal))
 	router.HandleFunc("/api/v0.1/torrents/{infohash}", BasicAuth(infohashMiddleware(apiTorrent)))
 	router.HandleFunc("/api/v0.1/torrents/{infohash}/filelist", BasicAuth(infohashMiddleware(apiFileList)))
 


### PR DESCRIPTION

#  Content:
The `/api/v0.1/torrentstotal` endpoint is used to get the total count of queried torrents.<br />
When querying torrents through the `/api/v0.1/torrents` endpoint, it only returns the data for the current page without specifying how many total records there are.<br />
The web interface, pagination is implemented by clicking "Load More". With this new endpoint, the total number of matching records can be fetched, making it easier to implement pagination in the web interface.
