### PR TITLE
improve the clarity of the `torrentstotal` semantics

### DIFF
--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -54,13 +54,6 @@ const (
 	ByUpdatedOn
 )
 
-type CountQueryTorrentsType uint8
-
-const (
-	CountQueryTorrentsByAll CountQueryTorrentsType = iota
-	CountQueryTorrentsByKeyword
-)
-
 // TODO: search `swtich (orderBy)` and see if all cases are covered all the time
 
 type databaseEngine uint8

--- a/persistence/interface.go
+++ b/persistence/interface.go
@@ -54,6 +54,13 @@ const (
 	ByUpdatedOn
 )
 
+type CountQueryTorrentsType uint8
+
+const (
+	CountQueryTorrentsByAll CountQueryTorrentsType = iota
+	CountQueryTorrentsByKeyword
+)
+
 // TODO: search `swtich (orderBy)` and see if all cases are covered all the time
 
 type databaseEngine uint8

--- a/web/torrents.go
+++ b/web/torrents.go
@@ -274,7 +274,7 @@ func apiTorrentsTotal(w http.ResponseWriter, r *http.Request) {
 	var results map[string]any
 
 	switch queryCountType {
-	case persistence.CountQueryTorrentsByKeyword:
+	case CountQueryTorrentsByKeyword:
 		total, err := database.GetNumberOfQueryTorrents(tq.Query, tq.Epoch)
 		if err != nil {
 			http.Error(w, "GetNumberOfQueryTorrents: "+err.Error(), http.StatusInternalServerError)
@@ -320,13 +320,20 @@ func parseOrderBy(s string) (persistence.OrderingCriteria, error) {
 	}
 }
 
-func parseQueryCountType(s string) (persistence.CountQueryTorrentsType, error) {
+type CountQueryTorrentsType uint8
+
+const (
+	CountQueryTorrentsByAll CountQueryTorrentsType = iota
+	CountQueryTorrentsByKeyword
+)
+
+func parseQueryCountType(s string) (CountQueryTorrentsType, error) {
 	switch s {
 	case "byKeyword":
-		return persistence.CountQueryTorrentsByKeyword, nil
+		return CountQueryTorrentsByKeyword, nil
 	case "byAll":
-		return persistence.CountQueryTorrentsByAll, nil
+		return CountQueryTorrentsByAll, nil
 	default:
-		return persistence.CountQueryTorrentsByKeyword, fmt.Errorf("unknown queryType string: %s", s)
+		return CountQueryTorrentsByKeyword, fmt.Errorf("unknown queryType string: %s", s)
 	}
 }

--- a/web/torrents.go
+++ b/web/torrents.go
@@ -242,6 +242,7 @@ func apiTorrentsTotal(w http.ResponseWriter, r *http.Request) {
 		tq.NewLogic, err = strconv.ParseBool(r.Form.Get("newLogic"))
 		if err != nil {
 			http.Error(w, "error while parsing the URL: "+err.Error(), http.StatusBadRequest)
+			return
 		}
 	}
 

--- a/web/torrents_test.go
+++ b/web/torrents_test.go
@@ -246,3 +246,49 @@ func TestApiTorrentsTotal(t *testing.T) {
 		})
 	}
 }
+
+func TestParseQueryCountType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		input          string
+		expectedOutput persistence.CountQueryTorrentsType
+		expectedError  string
+	}{
+		{
+			name:           "Valid byKeyword",
+			input:          "byKeyword",
+			expectedOutput: persistence.CountQueryTorrentsByKeyword,
+			expectedError:  "",
+		},
+		{
+			name:           "Valid byAll",
+			input:          "byAll",
+			expectedOutput: persistence.CountQueryTorrentsByAll,
+			expectedError:  "",
+		},
+		{
+			name:           "Invalid queryType",
+			input:          "invalidType",
+			expectedOutput: persistence.CountQueryTorrentsByKeyword,
+			expectedError:  "unknown queryType string: invalidType",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := parseQueryCountType(tt.input)
+
+			if err != nil && err.Error() != tt.expectedError {
+				t.Errorf("expected error %v, got %v", tt.expectedError, err.Error())
+			} else if err == nil && tt.expectedError != "" {
+				t.Errorf("expected error %v, got nil", tt.expectedError)
+			}
+
+			if output != tt.expectedOutput {
+				t.Errorf("expected output %v, got %v", tt.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/web/torrents_test.go
+++ b/web/torrents_test.go
@@ -204,7 +204,7 @@ func TestApiTorrentsTotal(t *testing.T) {
 			name:           "valid request with newLogic=true",
 			queryParams:    "epoch=1234567890&newLogic=true&queryType=byKeyword",
 			expectedStatus: http.StatusOK,
-			expectedError:  `{"queryType":"byKeyword","data":12345}`,
+			expectedError:  `{"data":0,"queryType":"byKeyword"}`,
 		},
 		{
 			name:           "invalid queryType",
@@ -253,25 +253,25 @@ func TestParseQueryCountType(t *testing.T) {
 	tests := []struct {
 		name           string
 		input          string
-		expectedOutput persistence.CountQueryTorrentsType
+		expectedOutput CountQueryTorrentsType
 		expectedError  string
 	}{
 		{
 			name:           "Valid byKeyword",
 			input:          "byKeyword",
-			expectedOutput: persistence.CountQueryTorrentsByKeyword,
+			expectedOutput: CountQueryTorrentsByKeyword,
 			expectedError:  "",
 		},
 		{
 			name:           "Valid byAll",
 			input:          "byAll",
-			expectedOutput: persistence.CountQueryTorrentsByAll,
+			expectedOutput: CountQueryTorrentsByAll,
 			expectedError:  "",
 		},
 		{
 			name:           "Invalid queryType",
 			input:          "invalidType",
-			expectedOutput: persistence.CountQueryTorrentsByKeyword,
+			expectedOutput: CountQueryTorrentsByKeyword,
 			expectedError:  "unknown queryType string: invalidType",
 		},
 	}

--- a/web/torrents_test.go
+++ b/web/torrents_test.go
@@ -180,7 +180,7 @@ func TestApiTorrentsTotal(t *testing.T) {
 		},
 		{
 			name:           "valid request with epoch",
-			queryParams:    "epoch=1234567890",
+			queryParams:    "epoch=1234567890&query=testQuery",
 			expectedStatus: http.StatusOK,
 		},
 		{
@@ -200,11 +200,29 @@ func TestApiTorrentsTotal(t *testing.T) {
 			queryParams:    "epoch=1234567890&lastOrderedValue=123.45&lastID=123",
 			expectedStatus: http.StatusOK,
 		},
+		{
+			name:           "valid request with newLogic=true",
+			queryParams:    "epoch=1234567890&newLogic=true&queryType=byKeyword",
+			expectedStatus: http.StatusOK,
+			expectedError:  `{"queryType":"byKeyword","data":12345}`,
+		},
+		{
+			name:           "invalid queryType",
+			queryParams:    "epoch=1234567890&newLogic=true&queryType=invalidType",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "error while parsing the URL: unknown queryType string: invalidType",
+		},
+		{
+			name:           "invalid newLogic parameter",
+			queryParams:    "epoch=1234567890&newLogic=bool",
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "error while parsing the URL: strconv.ParseBool: parsing \"bool\": invalid syntax",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := http.NewRequest("GET", "/api/torrents/total?"+tt.queryParams, nil)
+			req, err := http.NewRequest("GET", "/api/torrentstotal?"+tt.queryParams, nil)
 			if err != nil {
 				t.Fatalf("could not create request: %v", err)
 			}


### PR DESCRIPTION
## Brief Description:
Here is my revised update for issue #540 .
Compatibility has now been implemented.

## Detailed Description:

### API Definition:
At the time, I mistakenly thought it was possible to paginate by specifying a page number (as detailed in #535), without realizing that pagination could only be achieved using cursors. As a result, I pushed #540 for changes. 
The functionality of this API has now been modified to return an approximate count of results that can be fetched.

### Update Summary: 
This is my revised update for issue #540. Compatibility has now been implemented. Two new parameters, **NewLogic** and **QueryType**, have been added.

- **NewLogic** controls compatibility: when set to `true`, the response will use the new JSON format; when set to `false`, it will use the old response format.
- **QueryType** enhances the API’s functionality to avoid issues arising from potential misunderstandings. Currently, it only supports total count queries by keyword, and it requires **NewLogic=true** to be effective.

### Regarding the usage of this API: 
A frontend interface was created using AI, and I initially implemented both "previous" and "next" pagination. However, I was unable to achieve the specific page navigation functionality I intended. After modifying the API, it now provides an approximate count of results (e.g., "Approximately xxx items found"). Pagination has been implemented using cursor-based pagination, which also improves the experience on mobile devices.