### PR TITLE
ci: update Go version to 1.24 in workflow files and configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -55,10 +55,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up Go 1.23
+    - name: Set up Go 1.24
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: 1.24
 
     - name: Build
       env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ '1.23', '1.24.0-rc.3' ]
+        go-version: [ '1.23', '1.24' ]
 
     steps:
 
@@ -51,7 +51,7 @@ jobs:
         files: ./coverage.out
         flags: unittests
         verbose: true
-      if: ${{ matrix.go-version == '1.23' }}
+      if: ${{ matrix.go-version == '1.24' }}
 
     - name: GoLang CI Lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,16 +19,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - { go-version: 1.23, go-os: linux, go-arch: amd64 }
-          - { go-version: 1.23, go-os: linux, go-arch: 386 }
-          - { go-version: 1.23, go-os: linux, go-arch: arm64 }
-          - { go-version: 1.23, go-os: linux, go-arch: arm }
-          - { go-version: 1.23, go-os: openbsd, go-arch: amd64 }
-          - { go-version: 1.23, go-os: openbsd, go-arch: 386 }
-          - { go-version: 1.23, go-os: openbsd, go-arch: arm64 }
-          - { go-version: 1.23, go-os: openbsd, go-arch: arm }
-          - { go-version: 1.23, go-os: darwin, go-arch: arm64 }
-          - { go-version: 1.23, go-os: freebsd, go-arch: amd64 }
+          - { go-version: 1.24, go-os: linux, go-arch: amd64 }
+          - { go-version: 1.24, go-os: linux, go-arch: 386 }
+          - { go-version: 1.24, go-os: linux, go-arch: arm64 }
+          - { go-version: 1.24, go-os: linux, go-arch: arm }
+          - { go-version: 1.24, go-os: openbsd, go-arch: amd64 }
+          - { go-version: 1.24, go-os: openbsd, go-arch: 386 }
+          - { go-version: 1.24, go-os: openbsd, go-arch: arm64 }
+          - { go-version: 1.24, go-os: openbsd, go-arch: arm }
+          - { go-version: 1.24, go-os: darwin, go-arch: arm64 }
+          - { go-version: 1.24, go-os: freebsd, go-arch: amd64 }
 
     steps:
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,36 +11,18 @@ linters:
     - gci
 
 issues:
-  new: true
   exclude-rules:
-
-    - linters:
-        - staticcheck
-      text: "SA4027:"
-
-    - linters:
-        - staticcheck
-      text: "ST1005:"
 
     - text: "weak random number generator"
       linters:
         - gosec
 
+    # The BitTorrent protocol is based upon weak cryptographic primitives
+    # it's pointless to be stubborn about their usage
     - text: "weak cryptographic primitive"
       linters:
         - gosec
 
-    - path: dht/mainline/routingTable.go
-      text: "integer overflow conversion uint -> int"
-      linters:
-        - gosec
-
-    - path: main.go
-      text: "integer overflow conversion uint -> int"
-      linters:
-        - gosec
-    
-    - path: persistence/postgres.go
-      text: "G115: integer overflow conversion int64 -> uint"
+    - text: "G115: integer overflow conversion"
       linters:
         - gosec

--- a/bencode/bytes_test.go
+++ b/bencode/bytes_test.go
@@ -9,7 +9,9 @@ func TestBytesMarshalNil(t *testing.T) {
 	t.Parallel()
 
 	var b Bytes
-	Marshal(b)
+	if _, err := Marshal(b); err == nil {
+		t.Error("Marshal did not fail with error: marshalled Bytes should not be zero-length")
+	}
 }
 
 type structWithBytes struct {

--- a/bencode/decode.go
+++ b/bencode/decode.go
@@ -518,7 +518,9 @@ func (d *Decoder) readOneValue() bool {
 		panic(err)
 	}
 	if b == 'e' {
-		d.r.UnreadByte()
+		if err := d.r.UnreadByte(); err != nil {
+			panic(err)
+		}
 		return false
 	} else {
 		d.Offset++

--- a/bencode/decode_test.go
+++ b/bencode/decode_test.go
@@ -307,8 +307,12 @@ func decodeHugeString(strLen int64, header, tail string, v interface{}, maxStrLe
 	r, w := io.Pipe()
 	go func() {
 		fmt.Fprintf(w, header, strLen)
-		io.CopyN(w, arbitraryReader{}, strLen)
-		w.Write([]byte(tail))
+		if _, err := io.CopyN(w, arbitraryReader{}, strLen); err != nil {
+			panic(err)
+		}
+		if _, err := w.Write([]byte(tail)); err != nil {
+			panic(err)
+		}
 		w.Close()
 	}()
 	d := NewDecoder(r)

--- a/metainfo/magnet-v2.go
+++ b/metainfo/magnet-v2.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/multiformats/go-multihash"
-
 	"tgragnato.it/magnetico/types/infohash"
 	infohash_v2 "tgragnato.it/magnetico/types/infohash-v2"
 )

--- a/metainfo/magnet_test.go
+++ b/metainfo/magnet_test.go
@@ -18,7 +18,10 @@ var (
 )
 
 func init() {
-	hex.Decode(exampleMagnet.InfoHash[:], []byte("51340689c960f0778a4387aef9b4b52fd08390cd"))
+	_, err := hex.Decode(exampleMagnet.InfoHash[:], []byte("51340689c960f0778a4387aef9b4b52fd08390cd"))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Converting from our Magnet type to URL string.

--- a/persistence/interface_test.go
+++ b/persistence/interface_test.go
@@ -150,7 +150,9 @@ func TestMakeExport_WithContent_JSON(t *testing.T) {
 
 	db := newDb(t)
 	for _, st := range data {
-		db.AddNewTorrent(infoHash, st.Name, st.Files)
+		if err := db.AddNewTorrent(infoHash, st.Name, st.Files); err != nil {
+			t.Fatalf("Failed to add torrent to database: %v", err)
+		}
 	}
 
 	err = MakeExport(db, exportPath, make(chan os.Signal, 1))

--- a/stats/pyroscope_test.go
+++ b/stats/pyroscope_test.go
@@ -52,7 +52,9 @@ func TestInitPyroscope(t *testing.T) {
 			}
 
 			if profiler != nil {
-				profiler.Stop()
+				if err := profiler.Stop(); err != nil {
+					t.Errorf("error stopping profiler: %v", err)
+				}
 			}
 		})
 	}

--- a/types/infohash-v2/infohash-v2.go
+++ b/types/infohash-v2/infohash-v2.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/multiformats/go-multihash"
-
 	"tgragnato.it/magnetico/types/infohash"
 )
 
@@ -21,7 +20,9 @@ var _ fmt.Formatter = (*T)(nil)
 func (t *T) Format(f fmt.State, c rune) {
 	// TODO: I can't figure out a nice way to just override the 'x' rune, since it's meaningless
 	// with the "default" 'v', or .String() already returning the hex.
-	f.Write([]byte(t.HexString()))
+	if _, err := f.Write([]byte(t.HexString())); err != nil {
+		panic(err)
+	}
 }
 
 func (t *T) Bytes() []byte {

--- a/types/infohash/infohash.go
+++ b/types/infohash/infohash.go
@@ -18,7 +18,10 @@ var _ fmt.Formatter = (*T)(nil)
 func (t T) Format(f fmt.State, c rune) {
 	// TODO: I can't figure out a nice way to just override the 'x' rune, since it's meaningless
 	// with the "default" 'v', or .String() already returning the hex.
-	f.Write([]byte(t.HexString()))
+	_, err := f.Write([]byte(t.HexString()))
+	if err != nil {
+		panic(err)
+	}
 }
 
 func (t T) Bytes() []byte {
@@ -40,10 +43,6 @@ func (t T) HexString() string {
 func (t *T) FromHexString(s string) (err error) {
 	if len(s) != 2*Size {
 		err = fmt.Errorf("hash hex string has bad length: %d", len(s))
-		return
-	}
-	if len(s) == 0 {
-		*t = T{}
 		return
 	}
 	n, err := hex.Decode(t[:], []byte(s))
@@ -74,9 +73,8 @@ func (t T) MarshalText() (text []byte, err error) {
 }
 
 func FromHexString(s string) (h T) {
-	err := h.FromHexString(s)
-	if err != nil {
-		h.FromHexString("")
+	if err := h.FromHexString(s); err != nil {
+		h = T{}
 	}
 	return
 }

--- a/web/router.go
+++ b/web/router.go
@@ -72,7 +72,9 @@ func makeRouter() *http.ServeMux {
 
 func robotsHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(ContentType, "text/plain")
-	w.Write([]byte("User-agent: *\nDisallow: /\n"))
+	if _, err := w.Write([]byte("User-agent: *\nDisallow: /\n")); err != nil {
+		http.Error(w, "Failed to write response: "+err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func infohashMiddleware(next http.HandlerFunc) http.HandlerFunc {


### PR DESCRIPTION
https://go.dev/doc/go1.24

TODO: golangci-lint is not yet compatible with the new release