### PR TITLE
search entries located within file paths

### DIFF
--- a/persistence/postgres_test.go
+++ b/persistence/postgres_test.go
@@ -824,8 +824,43 @@ func TestPostgresDatabase_SetupDatabase(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"MAX(schema_version)"}).AddRow(0))
 
 	mock.ExpectExec(`
-		CREATE INDEX IF NOT EXISTS idx_files_path_gin_trgm ON files USING GIN \(path gin_trgm_ops\);
-		INSERT INTO migrations \(schema_version\) VALUES \(1\);
+			-- Rename the existing table
+			ALTER TABLE files RENAME TO files_old;
+
+			-- Create the new partitioned table
+			CREATE TABLE files \(
+				id          INTEGER PRIMARY KEY DEFAULT nextval\('seq_files_id'\),
+				torrent_id  INTEGER REFERENCES torrents ON DELETE CASCADE ON UPDATE RESTRICT,
+				size        BIGINT NOT NULL,
+				path        TEXT NOT NULL
+			\) PARTITION BY HASH \(id\);
+
+			-- Create the partitions
+			DO \$\$
+			BEGIN
+				FOR i IN 0..99 LOOP
+					EXECUTE format\(
+						'CREATE TABLE files_p%s PARTITION OF files FOR VALUES WITH \(MODULUS 100, REMAINDER %s\);',
+						i, i
+					\);
+					EXECUTE format\(
+						'CREATE INDEX IF NOT EXISTS idx_files_torrent_id_p%s ON files_p%s \(torrent_id\);',
+						i, i
+					\);
+					EXECUTE format\(
+						'CREATE INDEX IF NOT EXISTS idx_files_path_gin_trgm_p%s ON files_p%s USING GIN \(path gin_trgm_ops\);',
+						i, i
+					\);
+				END LOOP;
+			END\$\$;
+
+			-- Copy data from the old table to the new partitioned table
+			INSERT INTO files \(id, torrent_id, size, path\) SELECT id, torrent_id, size, path FROM files_old;
+
+			-- Drop the old indexes, table and finalize the migration
+			DROP INDEX IF EXISTS idx_files_torrent_id;
+			DROP TABLE IF EXISTS files_old;
+			INSERT INTO migrations \(schema_version\) VALUES \(1\);
 	`).WillReturnResult(sqlmock.NewResult(0, 0))
 
 	mock.ExpectCommit()


### PR DESCRIPTION
Ref: https://github.com/tgragnato/magnetico/issues/606

In addition to introducing the feature, I implemented table partitioning to improve performance.

In particular, operations such as `VACUUM`, `ANALYZE`, and `REINDEX` are less impactful when managed at the partition level, and some queries can be parallelized.

The partitioning is hash-based, which is useful when there is no temporal column and the data is evenly distributed.
