### PR TITLE
feat(dht): support bep33 in the mainline implementation

### DIFF
--- a/dht/mainline/bloom.go
+++ b/dht/mainline/bloom.go
@@ -1,0 +1,111 @@
+// Package mainline: Bloom filter implementation
+//
+// BEP-33 (DHT Scrapes) mandates a specific Bloom filter algorithm:
+//  - k = 2, m = 256*8 (2048 bits)
+//  - insertion: SHA-1(ip) and use the first 4 bytes to derive two indices
+//  - exact 256-byte representation for network bencode fields (BFsd/BFpe)
+
+package mainline
+
+import (
+	"crypto/sha1"
+	"errors"
+	"math"
+	"net"
+)
+
+type BloomFilter struct {
+	m     uint
+	k     uint
+	bytes []byte
+}
+
+func NewBloomFilter() *BloomFilter {
+	return &BloomFilter{
+		m:     2048,
+		k:     2,
+		bytes: make([]byte, 256),
+	}
+}
+
+func (bf *BloomFilter) InsertIP(ip net.IP) {
+	canonical := ip.To4()
+	if canonical == nil {
+		canonical = ip.To16()
+	}
+	if canonical == nil {
+		return
+	}
+
+	hash := sha1.Sum(canonical)
+
+	index1 := uint(hash[0]) | uint(hash[1])<<8
+	index2 := uint(hash[2]) | uint(hash[3])<<8
+
+	index1 %= bf.m
+	index2 %= bf.m
+
+	bf.bytes[index1/8] |= 0x01 << (index1 % 8)
+	bf.bytes[index2/8] |= 0x01 << (index2 % 8)
+}
+
+func (bf *BloomFilter) Estimate() float64 {
+	var zeroBits uint = 0
+	for _, b := range bf.bytes {
+		for i := 0; i < 8; i++ {
+			if (b & (0x01 << i)) == 0 {
+				zeroBits++
+			}
+		}
+	}
+	if zeroBits == 0 {
+		return float64(bf.m)
+	}
+	c := float64(zeroBits)
+	if c > float64(bf.m-1) {
+		c = float64(bf.m - 1)
+	}
+
+	size := math.Log(c/float64(bf.m)) / (float64(bf.k) * math.Log(1.0-1.0/float64(bf.m)))
+	return size
+}
+
+func (bf *BloomFilter) RawBytes() []byte {
+	return bf.bytes
+}
+
+func (bf *BloomFilter) MarshalBencode() ([]byte, error) {
+	if bf == nil || len(bf.bytes) != 256 {
+		return []byte("0:"), nil
+	}
+	// Bencode representation of a 256-byte string is "256:" followed by the bytes
+	res := make([]byte, 0, 4+256)
+	res = append(res, []byte("256:")...)
+	res = append(res, bf.bytes...)
+	return res, nil
+}
+
+func (bf *BloomFilter) UnmarshalBencode(b []byte) error {
+	if len(b) == 0 {
+		return errors.New("empty bencode for bloom filter")
+	}
+	colonIdx := -1
+	for i, c := range b {
+		if c == ':' {
+			colonIdx = i
+			break
+		}
+	}
+	if colonIdx == -1 {
+		return errors.New("invalid bencode string (missing colon)")
+	}
+	data := b[colonIdx+1:]
+	if len(data) != 256 {
+		return errors.New("bloom filter must be 256 bytes")
+	}
+	bf.m = 2048
+	bf.k = 2
+	bf.bytes = make([]byte, 256)
+	copy(bf.bytes, data)
+	return nil
+}

--- a/dht/mainline/bloom_test.go
+++ b/dht/mainline/bloom_test.go
@@ -1,0 +1,53 @@
+package mainline
+
+import (
+	"encoding/hex"
+	"math"
+	"net"
+	"testing"
+)
+
+func TestBloomFilter_InsertIP(t *testing.T) {
+	bf := NewBloomFilter()
+
+	// 192.0.2.0 - 192.0.2.255
+	for i := 0; i <= 255; i++ {
+		ip := net.IPv4(192, 0, 2, byte(i))
+		bf.InsertIP(ip)
+	}
+
+	// 2001:DB8:: - 2001:DB8::3E7
+	// Note: 3E7 in hex is 999 in decimal.
+	for i := 0; i <= 999; i++ {
+		ipBytes := make([]byte, 16)
+		ipBytes[0], ipBytes[1] = 0x20, 0x01
+		ipBytes[2], ipBytes[3] = 0x0d, 0xb8
+		ipBytes[14] = byte(i >> 8)
+		ipBytes[15] = byte(i & 0xff)
+		ip := net.IP(ipBytes)
+		bf.InsertIP(ip)
+	}
+
+	expectedHex := "f6c3f5eaa07ffd91bde89f777f26fb2bff37bdb8fb2bbaa2fd3ddde7bacfff75ee7ccbae" +
+		"fe5eedb1fbfaff67f6abff5e43ddbca3fd9b9ffdf4ffd3e9dff12d1bdf59db53dbe9fa5b" +
+		"7ff3b8fdfcde1afb8bedd7be2f3ee71ebbbfe93bcdeefe148246c2bc5dbff7e7efdcf24f" +
+		"d8dc7adffd8fffdfddfff7a4bbeedf5cb95ce81fc7fcff1ff4ffffdfe5f7fdcbb7fd79b3" +
+		"fa1fc77bfe07fff905b7b7ffc7fefeffe0b8370bb0cd3f5b7f2bd93feb4386cfdd6f7fd5" +
+		"bfaf2e9ebffffeecd67adbf7c67f17efd5d75eba6ffeba7fff47a91eb1bfbb53e8abfb57" +
+		"62abe8ff237279bfefbfeef5ffc5febfdfe5adffadfee1fb737ffffbfd9f6aeffeee76b6" +
+		"fd8f72ef"
+
+	actualHex := hex.EncodeToString(bf.RawBytes())
+	if actualHex != expectedHex {
+		t.Errorf("BloomFilter test vector mismatch.\nExpected:\n%s\nGot:\n%s", expectedHex, actualHex)
+	}
+
+	// For the 1256 inserted values the calculated estimate should be 1224.9308
+	expectedEstimate := 1224.9308
+	actualEstimate := bf.Estimate()
+
+	// Compare with small tolerance
+	if math.Abs(actualEstimate-expectedEstimate) > 0.0001 {
+		t.Errorf("Estimate mismatch. Expected %f, got %f", expectedEstimate, actualEstimate)
+	}
+}

--- a/dht/mainline/codec.go
+++ b/dht/mainline/codec.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"regexp"
 
-	"github.com/bits-and-blooms/bloom/v3"
 	"tgragnato.it/magnetico/v2/bencode"
 )
 
@@ -58,7 +57,7 @@ type QueryArguments struct {
 	//   - `BFpe`: Bloom Filter (256 bytes) representing all stored peers (leeches) for that
 	//             infohash
 	// Defined in BEP 33 "DHT Scrapes" for `get_peers` queries.
-	Scrape int `bencode:"noseed,omitempty"`
+	Scrape int `bencode:"scrape,omitempty"`
 }
 
 type ResponseValues struct {
@@ -84,10 +83,9 @@ type ResponseValues struct {
 	// below two fields to the "r" dictionary in the response:
 	// Defined in BEP 33 "DHT Scrapes" for responses to `get_peers` queries.
 	// Bloom Filter (256 bytes) representing all stored seeds for that infohash:
-	BFsd *bloom.BloomFilter `bencode:"BFsd,omitempty"`
+	BFsd *BloomFilter `bencode:"BFsd,omitempty"`
 	// Bloom Filter (256 bytes) representing all stored peers (leeches) for that infohash:
-	BFpe *bloom.BloomFilter `bencode:"BFpe,omitempty"`
-	// TODO: write marshallers for those fields above ^^
+	BFpe *BloomFilter `bencode:"BFpe,omitempty"`
 }
 
 type Error struct {

--- a/dht/mainline/indexingService.go
+++ b/dht/mainline/indexingService.go
@@ -295,6 +295,8 @@ func (is *IndexingService) onGetPeersQuery(msg *Message, addr *net.UDPAddr) {
 			is.nodeID,
 			is.protocol.CalculateToken(addr.IP),
 			compactPeers,
+			nil,
+			nil,
 		),
 		addr,
 	)

--- a/dht/mainline/protocol.go
+++ b/dht/mainline/protocol.go
@@ -280,7 +280,7 @@ func NewFindNodeResponse(t []byte, id []byte, nodes []CompactNodeInfo) *Message 
 	}
 }
 
-func NewGetPeersResponseWithValues(t []byte, id []byte, token []byte, values []CompactPeer) *Message {
+func NewGetPeersResponseWithValues(t []byte, id []byte, token []byte, values []CompactPeer, bfSdBf *BloomFilter, bfPeBf *BloomFilter) *Message {
 	return &Message{
 		Y: "r",
 		T: t,
@@ -288,6 +288,8 @@ func NewGetPeersResponseWithValues(t []byte, id []byte, token []byte, values []C
 			ID:     id,
 			Token:  token,
 			Values: values,
+			BFsd:   bfSdBf,
+			BFpe:   bfPeBf,
 		},
 	}
 }

--- a/dht/mainline/protocol_test.go
+++ b/dht/mainline/protocol_test.go
@@ -271,7 +271,7 @@ func TestNewGetPeersResponseWithNodes(t *testing.T) {
 
 func TestNewGetPeersResponseWithValues(t *testing.T) {
 	t.Parallel()
-	if !validateGetPeersResponseMessage(NewGetPeersResponseWithValues([]byte("tt"), []byte("qwertyuopasdfghjklzx"), []byte("token"), []CompactPeer{})) {
+	if !validateGetPeersResponseMessage(NewGetPeersResponseWithValues([]byte("tt"), []byte("qwertyuopasdfghjklzx"), []byte("token"), []CompactPeer{}, nil, nil)) {
 		t.Errorf("NewGetPeersResponseWithValues returned an invalid message!")
 	}
 }
@@ -529,6 +529,8 @@ func TestOnMessage_GetPeersResponse(t *testing.T) {
 			[]byte("abcdefghij0123456789"),
 			[]byte("token"),
 			[]CompactPeer{},
+			nil,
+			nil,
 		),
 		&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 6881},
 	)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.26.0
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/andybalholm/brotli v1.2.1
-	github.com/bits-and-blooms/bloom/v3 v3.7.1
 	github.com/goccy/go-yaml v1.19.2
 	github.com/grafana/pyroscope-go v1.3.1
 	github.com/jackc/pgx/v5 v5.10.0
@@ -24,7 +23,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bits-and-blooms/bitset v1.24.5 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,11 +4,6 @@ github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eT
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bits-and-blooms/bitset v1.24.5 h1:654xBVHc23gJMAgOTkPNoCVfiRxuIOAUnAZFtopqJ4w=
-github.com/bits-and-blooms/bitset v1.24.5/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/bits-and-blooms/bloom/v3 v3.7.1 h1:WXovk4TRKZttAMJfoQx6K2DM0zNIt8w+c67UqO+etV0=
-github.com/bits-and-blooms/bloom/v3 v3.7.1/go.mod h1:rZzYLLje2dfzXfAkJNxQQHsKurAyK55KUnL43Euk0hU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -75,8 +70,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
-github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=


### PR DESCRIPTION
Closes #499 

[bits-and-blooms/bloom/v3](https://github.com/bits-and-blooms/bloom) uses a murmur3-based hash function internally
BEP33 mandates the use of SHA-1 and a different API/serialization format